### PR TITLE
폰트 데모 추가

### DIFF
--- a/_includes/font-demo.html
+++ b/_includes/font-demo.html
@@ -1,0 +1,18 @@
+<div class="FontDemo">
+  <div class="FontDemo-optionContainer">
+    <div class="FontDemo-weightOptionContainer">
+      <span class="FontDemo-weightOption FontDemo-weightOption--thin" data-weight="100">A</span>
+      <span class="FontDemo-weightOption FontDemo-weightOption--regular" data-weight="400">A</span>
+      <span class="FontDemo-weightOption FontDemo-weightOption--bold" data-weight="700">A</span>
+    </div>
+    <div class="FontDemo-sizeOptionContainer">
+      <span class="FontDemo-sizeOptionLabel FontDemo-sizeOptionLabel--small"
+      >A</span
+      ><input type="range" class="FontDemo-sizeOption" min="10" max="40" value="20" /
+      ><span class="FontDemo-sizeOptionLabel FontDemo-sizeOptionLabel--large"
+      >A</span>
+    </div>
+    <div class="FontDemo-guideText">직접 입력해보세요.</div>
+  </div>
+  <div class="FontDemo-demo" contenteditable placeholder="직접 입력해보세요.">{{ include.text }}</div>
+</div>

--- a/_sass/_dropdown.scss
+++ b/_sass/_dropdown.scss
@@ -50,7 +50,7 @@
     padding: 3px 40px 3px 20px;
     clear: both;
     font-weight: normal;
-    line-height: 2.5em;
+    line-height: 2.5;
     color: $text-color;
     white-space: nowrap; // prevent links from randomly breaking onto new lines
     transition: background .2s ease;

--- a/_sass/_font-demo.scss
+++ b/_sass/_font-demo.scss
@@ -1,0 +1,157 @@
+.FontDemo {
+  width: 100%;
+  min-height: 100px;
+  &-optionContainer {
+    overflow: hidden;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    opacity: 0;
+    transition: opacity 0.3s;
+    -webkit-transition: opacity 0.3s;
+    .FontDemo:hover & {
+      opacity: 1;
+    }
+    &:after {
+      display: table;
+      clear: both;
+      content: '';
+    }
+  }
+  &-weightOptionContainer {
+    float: left;
+    font-size: 20px;
+  }
+  &-weightOption {
+    cursor: pointer;
+    padding: 0 3px;
+    &--thin {
+      font-weight: 100;
+    }
+    &--regular {
+      font-weight: 400;
+    }
+    &--bold {
+      font-weight: 700;
+    }
+  }
+  &-sizeOptionContainer {
+    float: left;
+    margin-left: 40px;
+  }
+  &-sizeOption {
+    height: 12px;
+    margin: 0 5px;
+  }
+  &-sizeOptionLabel {
+    &--small {
+      font-size: 12px;
+      vertical-align: 2px;
+    }
+    &--large {
+      font-size: 20px;
+      vertical-align: 0;
+    }
+  }
+  &-guideText {
+    float: right;
+  }
+  &-demo {
+    outline: 0;
+    margin-top: 10px;
+    min-width: 100px;
+    &:empty:before{
+      content: attr(placeholder);
+      display: block; /* For Firefox */
+      color: #999;
+    }
+  }
+}
+
+/*
+http://danielstern.ca/range.css
+코드 생성 후 최상단의 width, margin 삭제
+*/
+input[type=range].FontDemo-sizeOption {
+  -webkit-appearance: none;
+}
+input[type=range].FontDemo-sizeOption:focus {
+  outline: none;
+}
+input[type=range].FontDemo-sizeOption::-webkit-slider-runnable-track {
+  width: 100%;
+  height: 1px;
+  cursor: pointer;
+  box-shadow: 0px 0px 0px #000000, 0px 0px 0px #0d0d0d;
+  background: #333333;
+  border-radius: 0px;
+  border: 0px solid #333333;
+}
+input[type=range].FontDemo-sizeOption::-webkit-slider-thumb {
+  box-shadow: 0px 0px 0px #ffffff, 0px 0px 0px #ffffff;
+  border: 2px solid #ffffff;
+  height: 15px;
+  width: 15px;
+  border-radius: 8px;
+  background: #333333;
+  cursor: pointer;
+  -webkit-appearance: none;
+  margin-top: -7px;
+}
+input[type=range].FontDemo-sizeOption:focus::-webkit-slider-runnable-track {
+  background: #404040;
+}
+input[type=range].FontDemo-sizeOption::-moz-range-track {
+  width: 100%;
+  height: 1px;
+  cursor: pointer;
+  box-shadow: 0px 0px 0px #000000, 0px 0px 0px #0d0d0d;
+  background: #333333;
+  border-radius: 0px;
+  border: 0px solid #333333;
+}
+input[type=range].FontDemo-sizeOption::-moz-range-thumb {
+  box-shadow: 0px 0px 0px #ffffff, 0px 0px 0px #ffffff;
+  border: 2px solid #ffffff;
+  height: 15px;
+  width: 15px;
+  border-radius: 8px;
+  background: #333333;
+  cursor: pointer;
+}
+input[type=range].FontDemo-sizeOption::-ms-track {
+  width: 100%;
+  height: 1px;
+  cursor: pointer;
+  background: transparent;
+  border-color: transparent;
+  color: transparent;
+}
+input[type=range].FontDemo-sizeOption::-ms-fill-lower {
+  background: #262626;
+  border: 0px solid #333333;
+  border-radius: 0px;
+  box-shadow: 0px 0px 0px #000000, 0px 0px 0px #0d0d0d;
+}
+input[type=range].FontDemo-sizeOption::-ms-fill-upper {
+  background: #333333;
+  border: 0px solid #333333;
+  border-radius: 0px;
+  box-shadow: 0px 0px 0px #000000, 0px 0px 0px #0d0d0d;
+}
+input[type=range].FontDemo-sizeOption::-ms-thumb {
+  box-shadow: 0px 0px 0px #ffffff, 0px 0px 0px #ffffff;
+  border: 2px solid #ffffff;
+  height: 15px;
+  width: 15px;
+  border-radius: 8px;
+  background: #333333;
+  cursor: pointer;
+  height: 1px;
+}
+input[type=range].FontDemo-sizeOption:focus::-ms-fill-lower {
+  background: #333333;
+}
+input[type=range].FontDemo-sizeOption:focus::-ms-fill-upper {
+  background: #404040;
+}

--- a/_sass/_type.scss
+++ b/_sass/_type.scss
@@ -12,7 +12,7 @@
 body {
   font-family: $font-family-base;
   font-size: $font-size-base;
-  line-height: 1.5em;
+  line-height: 1.5;
   color: $text-color;
   font-weight: 400;
   -webkit-font-smoothing: antialiased;
@@ -20,7 +20,7 @@ body {
 
   &:lang(ja) {
     font-family: $font-family-jp;
-    line-height: 1.6em;
+    line-height: 1.6;
   }
 }
 
@@ -31,7 +31,7 @@ body {
 h1, h2, h3, h4, h5, h6 {
   margin-top: 1.5em;
   margin-bottom: 1em;
-  line-height: 1.3em;
+  line-height: 1.3;
 }
 
 h1, h2 {
@@ -97,7 +97,7 @@ dl {
 
 dt,
 dd {
-  line-height: 1.5em;
+  line-height: 1.5;
 }
 
 dt {

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -23,9 +23,9 @@ $grey-text-color:               $grey-5;
 $font-family-base:              'Spoqa Han Sans', 'Spoqa Han Sans JP', 'Source Sans Pro', Apple SD Gothic Neo, Nanum Barun Gothic, Nanum Gothic, Verdana, Arial, Dotum, sans-serif;
 $font-family-jp:                'Spoqa Han Sans JP', 'Spoqa Han Sans', 'Source Sans Pro', Apple SD Gothic Neo, Nanum Barun Gothic, Nanum Gothic, Verdana, Arial, Dotum, sans-serif;
 
-$line-height-base:              1.5em;
-$line-height-jp:                1.6em;
-$hading-line-height-jp:         1.3em;
+$line-height-base:              1.5;
+$line-height-jp:                1.6;
+$hading-line-height-jp:         1.3;
 
 //** Computed "line-height" (`font-size` * `line-height`) for use with `margin`, `padding`, etc.
 $line-height-computed:          floor(($font-size-base * $line-height-base)) !default; // ~20px

--- a/css/style.scss
+++ b/css/style.scss
@@ -41,6 +41,9 @@
 // Optional 
 @import "page-headers";
 
+// Font demo
+@import "font-demo";
+
 // ADhoc Style
 
 section h3 {

--- a/css/style.scss
+++ b/css/style.scss
@@ -105,12 +105,12 @@ section h3 {
   .glyphs {
     padding: 40px 0 50px;
     font-size: 90px;
-    line-height: 1em;
+    line-height: 1;
     font-weight: 400;
     border-bottom: 3px solid $primary-0;
 
     &.glyphs-glyphs {
-      line-height: 1.4em;
+      line-height: 1.4;
     }
 
     .edited {
@@ -241,7 +241,7 @@ section h3 {
     .img-number {
       padding: 60px 0;
       font-size: 110px;
-      line-height: 1.3em;
+      line-height: 1.3;
       text-align: center;
       font-weight: 200;
       letter-spacing: 20px;
@@ -249,7 +249,7 @@ section h3 {
     .img-text-weight {
       padding: 60px 0;
       font-size: 60px;
-      line-height: 1.3em;
+      line-height: 1.3;
       text-align: center;
       font-weight: bold;
     }
@@ -257,7 +257,7 @@ section h3 {
     .img-text-title {
       padding: 60px 0;
       font-size: 60px;
-      line-height: 1.3em;
+      line-height: 1.3;
       text-align: left;
       font-weight: bold;
     }

--- a/index.html
+++ b/index.html
@@ -239,7 +239,7 @@ layout: default
       </div>
     </section>
     <section class="fixed-container">
-     텍스트 써보는 내용이 들어갈 자리입니다.
+      {% include font-demo.html text="직접 작성해보세요." %}
     </section>
     <section class="fixed-container section-webfont">
       <h2 class="section-title">웹폰트로 사용하기</h2>
@@ -331,3 +331,26 @@ layout: default
         <a class="footer-menu" href="http://spoqa.github.io/">블로그</a>
       </div>
     </footer>
+    <script>
+    $(function() {
+      $('.FontDemo-weightOption').click(function (e) {
+        $this = $(this);
+        var weight = $this.data('weight');
+        $this.parents('.FontDemo')
+          .find('.FontDemo-demo')
+          .css('font-weight', weight);
+      });
+      $('.FontDemo-weightOption--regular').click();
+      $('.FontDemo-sizeOption').on('input change', function (e) {
+        var $this = $(this);
+        var size = $this.val();
+        $this.parents('.FontDemo')
+          .find('.FontDemo-demo')
+          .css('font-size', size + 'px');
+      }).change();
+      $('.FontDemo-demo').keypress(function (e) {
+        var key = e.which;
+        if(key == 13) return false;
+      });
+    })
+    </script>


### PR DESCRIPTION
폰트 데모를 추가했습니다.

처음에는 폰트 데모 부분의 height가 제대로 설정이 안 돼서, 조사해보니 [이와 같은 문제](https://developer.mozilla.org/en/docs/Web/CSS/line-height#Notes)가 있었습니다. (예시와 완전히 같은 문제가 발생) 

같은 문제가 생길 수 있는 여지를 없애고자 em단위로 설정되어 있는 line-height를 전부 unitless로 변경했습니다. 대충 슥 봤을 때는 별 문제가 없어 보였지만 혹시 의도하신 바와 다르게 스타일링이 되는 등의 문제가 있다면 해당 커밋을 revert한 후에 FontDemo 클래스에 대해서만 unitless line-height를 쓰면 될 것 같습니다.
